### PR TITLE
Try to calculate center from bounds if not available in metadata

### DIFF
--- a/datasette_tiles/__init__.py
+++ b/datasette_tiles/__init__.py
@@ -134,6 +134,10 @@ async def explorer(datasette, request):
         default_longitude, default_latitude, default_zoom = metadata["center"].split(
             ","
         )
+    elif metadata.get("bounds"):
+        xmin, ymin, xmax, ymax = metadata["bounds"].split(",")
+        default_latitude = (float(ymax) + float(ymin)) / 2
+        default_longitude = (float(xmax) + float(xmin)) / 2
     min_zoom = 0
     max_zoom = 19
     if metadata.get("minzoom"):


### PR DESCRIPTION
Sometimes `center` is not available in the `metadata` when setting `default_longitude` and `default_latitude`. This PR uses another fallback by trying to calculate it from the bounds (if available).